### PR TITLE
Page ranges and output improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ change the script's behavior by editing this file.
 * `API_KEY` - This must be set. Get your API key from https://account.shodan.io/.
 * `PAGES` - How many pages of results to query. Shodan returns 100 results per page. The first page is always free, but querying any pages
 beyond the first page will charge you 1 API credit. For example, if you set PAGES to 5, you will be charged 4 API credits total when you
-run the script. The first page is usually good enough anyway, it gets updated often as Shodan indexes new servers.
+run the script. The first page is usually good enough anyway, it gets updated often as Shodan indexes new servers. You can query a certain page range by specifying an inclusive range as a string e.g., `"4-8"` (pages 4 to 8)
 * `MC_VERSION` - Search for a specific Minecraft server version. You can leave this blank, but results may be less reliable and the script
 may not work correctly. I recommend having a Minecraft version set.
 * `ACTIVE_ONLY` - If you set this to `true`, IPs will only be output if Shodan shows that they have a non-zero Online Players count. This

--- a/griefbuddy.py
+++ b/griefbuddy.py
@@ -22,7 +22,6 @@ CONFIG = {}
 
 
 def do_request(page_num):
-    print(page_num)
     # construct API request
     api_params = {
         "key": CONFIG["API_KEY"],
@@ -63,6 +62,22 @@ def parse_page(page_json):
     return result
 
 
+def print_ips(ips):
+    if CONFIG["OUTPUT_FILE"] == "":
+        # print results to stdout
+        for ip in ips:
+            print(ip)
+    else:
+        try:
+            with open(CONFIG["OUTPUT_FILE"], "w") as f:
+                for ip in ips:
+                    f.write(ip + "\n")
+        except Exception as e:
+            print("Failed to open output file!")
+            print(e)
+            exit()
+
+
 if __name__ == "__main__":
     print("GriefBuddy 2021")
     print("I AM THE GREAT K0RNH0LI0!")
@@ -88,7 +103,6 @@ if __name__ == "__main__":
         exit()
 
     print("Searching for servers...")
-    server_results = []
 
     # parse the provided page range as an inclusive range
     lower_page = -1
@@ -104,18 +118,4 @@ if __name__ == "__main__":
 
         if resp is not None:
             ips = parse_page(resp)
-            server_results.extend(ips)
-
-    if CONFIG["OUTPUT_FILE"] == "":
-        # print results to stdout
-        for ip in server_results:
-            print(ip)
-    else:
-        try:
-            with open(CONFIG["OUTPUT_FILE"], "w") as f:
-                for ip in server_results:
-                    f.write(ip + "\n")
-        except Exception as e:
-            print("Failed to open output file!")
-            print(e)
-            exit()
+            print_ips(ips)  # print ips on the go in case of an error

--- a/griefbuddy.py
+++ b/griefbuddy.py
@@ -69,7 +69,7 @@ def print_ips(ips):
             print(ip)
     else:
         try:
-            with open(CONFIG["OUTPUT_FILE"], "w") as f:
+            with open(CONFIG["OUTPUT_FILE"], "a") as f:
                 for ip in ips:
                     f.write(ip + "\n")
         except Exception as e:
@@ -103,6 +103,10 @@ if __name__ == "__main__":
         exit()
 
     print("Searching for servers...")
+
+    # clear the file before appending
+    if CONFIG["OUTPUT_FILE"] != "":
+        open(CONFIG["OUTPUT_FILE"], 'w').close()
 
     # parse the provided page range as an inclusive range
     lower_page = -1

--- a/griefbuddy.py
+++ b/griefbuddy.py
@@ -20,7 +20,9 @@ PAGE_SIZE = 100
 # user config loaded from config.json
 CONFIG = {}
 
+
 def do_request(page_num):
+    print(page_num)
     # construct API request
     api_params = {
         "key": CONFIG["API_KEY"],
@@ -47,6 +49,7 @@ def do_request(page_num):
 
     return result
 
+
 def parse_page(page_json):
     result = []
     for server in page_json["matches"]:
@@ -58,6 +61,7 @@ def parse_page(page_json):
         port = str(server["port"])
         result.append(ip + ":" + port)
     return result
+
 
 if __name__ == "__main__":
     print("GriefBuddy 2021")
@@ -78,14 +82,25 @@ if __name__ == "__main__":
         print("put your API key in config.json.")
         exit()
 
-    if CONFIG["PAGES"] < 1:
+    page_range = CONFIG["PAGES"]
+    if isinstance(page_range, int) and page_range < 1:
         print("PAGES must be greater than 0.")
         exit()
 
     print("Searching for servers...")
     server_results = []
-    for i in range(CONFIG["PAGES"]):
-        resp = do_request(i + 1)
+
+    # parse the provided page range as an inclusive range
+    lower_page = -1
+    upper_page = -1
+    if isinstance(page_range, int):
+        lower_page = 1
+        upper_page = page_range
+    else:  # assume a range is given as a string
+        lower_page, upper_page = [int(x) for x in page_range.split("-")]
+
+    for i in range(lower_page, upper_page + 1):
+        resp = do_request(i)
 
         if resp is not None:
             ips = parse_page(resp)


### PR DESCRIPTION
IPs should be printed on the go in case you run into a 401 error from running out of credits (this happened to me, and I couldn't see the IPs that were already found).

It needs an option to specify page ranges since Shodan doesn't update often enough, and you don't want to query the same servers again.